### PR TITLE
chore: enable FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/run-validation.yml
+++ b/.github/workflows/run-validation.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` as a top-level environment variable to all GitHub Actions workflow files.

## What changed

- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the workflow-level `env:` block in each `.github/workflows/*.yml` file

## Why

GitHub is migrating JavaScript-based Actions from Node.js 20 to Node.js 24. Setting this environment variable opts in to running all JavaScript-based actions on the Node.js 24 runtime, ensuring compatibility ahead of the official cutover.

No action versions were modified — they are already on modern versions that support Node.js 24.
